### PR TITLE
Change the send_message trigger time

### DIFF
--- a/apns-send
+++ b/apns-send
@@ -3,6 +3,7 @@
 from apns import APNs, Payload
 
 import optparse
+import time
 
 from tornado import ioloop
 
@@ -41,14 +42,14 @@ if options.message is None:
 apns = APNs(cert_file=options.certificate_file, key_file=options.key_file, use_sandbox=True)
 
 def success():
-  print("Sent push message to APNS gateway.")
-  ioloop.IOLoop.instance().stop()
+    print("Sent push message to APNS gateway.")
+    ioloop.IOLoop.instance().stop()
 
 def send():
-	apns.gateway_server.send_notification(options.push_token, payload, success)
+    apns.gateway_server.send_notification(options.push_token, payload, success)
 
 # Send a notification
 payload = Payload(alert=options.message, sound="default", badge=1)
-apns.gateway_server.connect(send)
-
+apns.gateway_server.connect()
+ioloop.IOLoop.instance().add_timeout(time.time()+5, send)
 ioloop.IOLoop.instance().start()


### PR DESCRIPTION
With the current method through the tornado_apns project, we send message to
the APNS immediatly when the connect done. And we do a connect-disconnect
circle at every time we send a message. But the apple's document said "APNs
treats rapid connection and disconnection as a denial-of-service attack."
So, when we have large messages to send, we'd better keep a connectiong alive
for a long peroid.
I use the tornado_apns in my project like below:
Create a APNS instance
connect to the server for inition
Use send_notification when we have a send request
