### PR TITLE
Fix a bug: set APNsConnection _alive attribute to False when apns connectiong closed

### DIFF
--- a/apns-send
+++ b/apns-send
@@ -48,8 +48,14 @@ def success():
 def send():
     apns.gateway_server.send_notification(options.push_token, payload, success)
 
+def on_response(status, seq):
+    print "sent push message to APNS gateway error status %s seq %s" % (status, seq) 
+
+def on_connected():
+    apns.gateway_server.receive_response(on_response) 
+
 # Send a notification
 payload = Payload(alert=options.message, sound="default", badge=1)
-apns.gateway_server.connect(receive)
+apns.gateway_server.connect(on_connected)
 ioloop.IOLoop.instance().add_timeout(time.time()+5, send)
 ioloop.IOLoop.instance().start()

--- a/apns.py
+++ b/apns.py
@@ -162,8 +162,8 @@ class APNsConnection(object):
                     functools.partial(self._on_connected, callback))
 
     def _connecting_timeout_callback(self):
+        self._connecting = False
         if not self.is_alive():
-            self._connecting = False
             self.disconnect()
             raise ConnectionError('connect timeout')
 
@@ -178,7 +178,12 @@ class APNsConnection(object):
         self._stream.close()
 
     def set_close_callback(self, callback):
-        self._stream.set_close_callback(callback)
+        self._stream_close_final_callback = callback
+        self._stream.set_close_callback(self._stream_close_callback)
+
+    def _stream_close_callback(self):
+        self._alive = False
+        self._stream_close_final_callback()
 
     def read(self, n, callback):
         try:


### PR DESCRIPTION
Last weekend I found a bug with my apns provider application. When the apns disconnected, my application retry connecting and timeout. Because the stream_connect_callback method didn't set the APNsConnection attribute _alive to False，the timeout_callback didn't work so correct, that lead to the state of the APNsConnection confusion. 