### PR TITLE
fix README example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,7 @@ A Python library for interacting with the Apple Push Notification service
 ## Sample usage
 
 ```python
+import time
 from apns import APNs, Payload
 from tornado import ioloop
 
@@ -16,9 +17,11 @@ def success():
     ioloop.IOLoop.instance().stop()
 
 def send():
-    token_hex = 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b87'
+    token_hex = 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b87' #device token
     payload = Payload(alert="Hello World!", sound="default", badge=1)
-    apns.gateway_server.send_notification(token_hex, payload, success)
+    identifier = 1 # 一个任意的值，用于识别此消息。如果发送出现问题， 错误应答里会把identifier带回来 
+    expiry = time.time() + 3600 #离线消息超时时间， 如果小于0或等于0， APNS不会保存这条消息
+    apns.gateway_server.send_notification(identifier, expiry, token_hex, payload, success)
 
 def on_response(status, seq):
     print "sent push message to APNS gateway error status %s seq %s" % (status, seq) 
@@ -60,5 +63,5 @@ Written and maintained by Simon Whitaker at [Goo Software Ltd][goo] and tornado 
 
 Also thanks to [Ethan-Zhang](https://github.com/Ethan-Zhang) for contributing.
 
-[a1]:http://developer.apple.com/iphone/library/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Introduction/Introduction.html#//apple_ref/doc/uid/TP40008194-CH1-SW1
+[a1]:https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/LegacyFormat.html#//apple_ref/doc/uid/TP40008194-CH105-SW1
 [goo]:http://www.goosoftware.co.uk/


### PR DESCRIPTION
example of README error:
```
Traceback (most recent call last):
  File "tornado_pn.py", line 54, in <module>
    push(options)
  File "tornado_pn.py", line 40, in push
    ioloop.IOLoop.instance().add_timeout(time.time()+1, send(options))
  File "tornado_pn.py", line 30, in send
    apns.gateway_server.send_notification(token_hex, payload, success)
TypeError: send_notification() takes exactly 6 arguments (4 given)
```